### PR TITLE
Missing if statement curly brackets causing a PHP Error.

### DIFF
--- a/code/Dotdigitalgroup/Email/Model/Connector/Order.php
+++ b/code/Dotdigitalgroup/Email/Model/Connector/Order.php
@@ -285,8 +285,9 @@ class Dotdigitalgroup_Email_Model_Connector_Order
      */
     protected function _limitLength($value)
     {
-        if (strlen($value) > 250)
+        if (strlen($value) > 250) {
             $value = substr($value, 0, 250);
+        }
 
         return $value;
     }


### PR DESCRIPTION
Wrapped curly brackets "{" around if statement that were missing and causing an error message as the following - "PHP Parse error:  syntax error, unexpected '{' in /MagentoFolderPath/app/code/community/Dotdigitalgroup/Email/Model/Connector/Order.php on line 288"