### PR TITLE
Mark re-subscription as Imported if not Suppressed

### DIFF
--- a/code/Dotdigitalgroup/Email/Model/Sync/Contact/Update.php
+++ b/code/Dotdigitalgroup/Email/Model/Sync/Contact/Update.php
@@ -43,6 +43,8 @@ class Dotdigitalgroup_Email_Model_Sync_Contact_Update extends Dotdigitalgroup_Em
                     {
                         $apiContact = $this->_client->getContactByEmail($email);
                         $result = $this->_client->postContactsResubscribe( $apiContact );
+                    } else {
+                        $result = new StdClass;
                     }
                 }elseif ($item->getImportMode() == Dotdigitalgroup_Email_Model_Importer::MODE_SUBSCRIBER_UPDATE){
                     $email = $importData['email'];


### PR DESCRIPTION
Avoid having more than 100 'not imported' imports of type Subcriber_Resubscribe from blocking other imports by marking it as 'imported' if the API doesn't return a message to say that it's suppressed. Proposed solution for #162.