### PR TITLE
Requires fallback product list config field

### DIFF
--- a/code/Dotdigitalgroup/Email/etc/system.xml
+++ b/code/Dotdigitalgroup/Email/etc/system.xml
@@ -2065,6 +2065,7 @@
                         <product_list translate="label comment" module="ddg">
                             <label>Products</label>
                             <frontend_type>text</frontend_type>
+                            <validate>required-entry</validate>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>


### PR DESCRIPTION
Fixes exception thrown when no related products are available.

Dynamic Content URLs for upsell, cross-sell and related products throws an exception if no related products are found and no fallback products are provided.