### PR TITLE
Use Zend_DB_Expr class for columns with expressions

### DIFF
--- a/code/Dotdigitalgroup/Email/Model/Adminhtml/Dashboard/Tabs/Analysis/Orders.php
+++ b/code/Dotdigitalgroup/Email/Model/Adminhtml/Dashboard/Tabs/Analysis/Orders.php
@@ -69,11 +69,11 @@ class Dotdigitalgroup_Email_Model_Adminhtml_Dashboard_Tabs_Analysis_Orders
             $collection->getSelect()
                 ->columns(
                     array(
-                        'lifetime'    => "SUM({$expr})",
-                        'average'     => "AVG({$expr})",
-                        'total_count' => "COUNT({$expr})",
-                        'day_count' => "ROUND(COUNT({$expr}) / DATEDIFF(date(MAX(created_at)),
-                         date(MIN(created_at))), 2)"
+                        'lifetime'    => new Zend_Db_Expr("SUM({$expr})"),
+                        'average'     => new Zend_Db_Expr("AVG({$expr})"),
+                        'total_count' => new Zend_Db_Expr("COUNT({$expr})"),
+                        'day_count' => new Zend_Db_Expr("ROUND(COUNT({$expr}) / DATEDIFF(date(MAX(created_at)),
+                         date(MIN(created_at))), 2)")
                     )
                 )
                 ->where('main_table.status NOT IN(?)', $statuses)

--- a/code/Dotdigitalgroup/Email/Model/Adminhtml/Dashboard/Tabs/Analysis/Rfm.php
+++ b/code/Dotdigitalgroup/Email/Model/Adminhtml/Dashboard/Tabs/Analysis/Rfm.php
@@ -79,7 +79,7 @@ class Dotdigitalgroup_Email_Model_Adminhtml_Dashboard_Tabs_Analysis_Rfm
             ->columns(
                 array(
                     'customer_total_orders'        => "count(*)",
-                    'customer_average_order_value' => "SUM({$expr})/count(*)",
+                    'customer_average_order_value' => new Zend_Db_Expr("SUM({$expr})/count(*)"),
                     'last_order_days_ago'          => "DATEDIFF(date(NOW()) , date(MAX(created_at)))"
                 )
             )

--- a/code/Dotdigitalgroup/Email/Model/Resource/Contact.php
+++ b/code/Dotdigitalgroup/Email/Model/Resource/Contact.php
@@ -252,7 +252,7 @@ class Dotdigitalgroup_Email_Model_Resource_Contact extends Mage_Core_Model_Resou
             ->reset(Zend_Db_Select::ORDER)
             ->columns(
                 array(
-                    'customer_average_order_value' => "SUM({$expr})/count(*)",
+                    'customer_average_order_value' => new Zend_Db_Expr("SUM({$expr})/count(*)"),
                 )
             )->order('customer_average_order_value');
 


### PR DESCRIPTION
Without this fix for columns with expressions the select is generated with backticks. Which results in an error like the one below for \Dotdigitalgroup_Email_Model_Adminhtml_Dashboard_Tabs_Analysis_Rfm::getPreparedCollection.

`Unknown column 'SUM((IFNULL(main_table.base_total_invoiced, 0) - IFNULL(main_table.base_tax_invoiced, 0) - IFNULL(main_table.base_shipping_invoiced, 0) - (IFNULL(main_table.base_total_refunded, 0) - IFNULL(ma' in 'field list'`

You already use this in `code/Dotdigitalgroup/Email/sql/email_connector_setup/mysql4-upgrade-4.1.3-5.0.0.php:436`

