### PR TITLE
Change Column Name for Sweet Tooth Rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ You are welcome to contribute to dotmailer for Magento! You can either:
 - Fix a bug: please fork this repo and submit the Pull Request to our [Testing branch](https://github.com/dotmailer/dotmailer-magento-extension/tree/testing)
 - Request a feature on our [community forum](https://support.dotmailer.com/hc/en-gb/community/topics/200432508-Feedback-and-feature-requests)
 
+
+# V6.3.8
+
+###### Bug fixes
+- We've changed the validation of new subscribers for automation so that they no longer get enrolled multiple times into the new subscriber program.
+- Transactional emails can now be set up at website level.
+- We've fixed an order Insight data issue related to the data type for the following fields - "delivery_address" and "billing_address".
+- In the case where Magento's double opt-in setting ("Need to confirm") was enabled, we used to import subscribers before they confirmed; this is now fixed.
+- We've added a check to ensure that the first abandoned cart email is mapped before doing the send.
+
 # V6.3.7
 
 ###### Bug fixes

--- a/code/Dotdigitalgroup/Email/Helper/Transactional.php
+++ b/code/Dotdigitalgroup/Email/Helper/Transactional.php
@@ -14,76 +14,82 @@ class Dotdigitalgroup_Email_Helper_Transactional
 
     /**
      * Transactional Email enabled.
+     *
+     * @param null $storeId
      * @return bool
      */
-    public function isEnabled()
+    public function isEnabled($storeId = null)
     {
-        return Mage::getStoreConfigFlag(
-            self::XML_PATH_DDG_TRANSACTIONAL_ENABLED
-        );
+        return Mage::getStoreConfigFlag(self::XML_PATH_DDG_TRANSACTIONAL_ENABLED, $storeId);
     }
 
     /**
+     * @param null $storeId
      * @return mixed
      */
-    public function getSmtpHost()
+    public function getSmtpHost($storeId = null)
     {
-        return Mage::getStoreConfig(self::XML_PATH_DDG_TRANSACTIONAL_HOST);
+        return Mage::getStoreConfig(self::XML_PATH_DDG_TRANSACTIONAL_HOST, $storeId);
     }
 
     /**
+     * @param null $storeId
      * @return mixed
      */
-    public function getSmtpUsername()
+    public function getSmtpUsername($storeId = null)
     {
-        return Mage::getStoreConfig(self::XML_PATH_DDG_TRANSACTIONAL_USERNAME);
+        return Mage::getStoreConfig(self::XML_PATH_DDG_TRANSACTIONAL_USERNAME, $storeId);
     }
 
     /**
+     * @param null $storeId
      * @return mixed
      */
-    public function getSmtpPassword()
+    public function getSmtpPassword($storeId = null)
     {
-        return Mage::getStoreConfig(self::XML_PATH_DDG_TRANSACTIONAL_PASSWORD);
+        return Mage::getStoreConfig(self::XML_PATH_DDG_TRANSACTIONAL_PASSWORD, $storeId);
     }
 
     /**
+     * @param null $storeId
      * @return mixed
      */
-    public function getSmtpPort()
+    public function getSmtpPort($storeId = null)
     {
-        return Mage::getStoreConfig(self::XML_PATH_DDG_TRANSACTIONAL_PORT);
+        return Mage::getStoreConfig(self::XML_PATH_DDG_TRANSACTIONAL_PORT, $storeId);
     }
 
     /**
      * @return bool
      */
-    public function isDebugEnabled()
+    public function isDebugEnabled($storeId = null)
     {
-        return Mage::getStoreConfigFlag(self::XML_PATH_DDG_TRANSACTIONAL_DEBUG);
+        return Mage::getStoreConfigFlag(self::XML_PATH_DDG_TRANSACTIONAL_DEBUG, $storeId);
     }
 
     /**
+     * @param null $storeId
      * @return Zend_Mail_Transport_Smtp
      */
-    public function getTransport()
+    public function getTransport($storeId = null)
     {
         $config = array(
-            'port' => $this->getSmtpPort(),
+            'port' => $this->getSmtpPort($storeId),
             'auth' => 'login',
-            'username' => $this->getSmtpUsername(),
-            'password' => $this->getSmtpPassword(),
+            'username' => $this->getSmtpUsername($storeId),
+            'password' => $this->getSmtpPassword($storeId),
             'ssl' => 'tls'
         );
 
-        if ($this->isDebugEnabled()) {
+        if ($this->isDebugEnabled($storeId)) {
             $configToLog = $config;
             unset($configToLog['password']);
             Mage::log('Mail transport config : ' . implode(',', $configToLog));
         }
 
         $transport = new Zend_Mail_Transport_Smtp(
-            $this->getSmtpHost(), $config
+            $this->getSmtpHost($storeId),
+            $config
         );
 
         return $transport;

--- a/code/Dotdigitalgroup/Email/Model/Apiconnector/Customer.php
+++ b/code/Dotdigitalgroup/Email/Model/Apiconnector/Customer.php
@@ -176,7 +176,7 @@ class Dotdigitalgroup_Email_Model_Apiconnector_Customer
         $lastTransfers = $tbtReward->getTransfers()
             ->selectOnlyActive()
             ->addOrder(
-                'last_update_ts', Varien_Data_Collection::SORT_ORDER_DESC
+                'updated_at', Varien_Data_Collection::SORT_ORDER_DESC
             );
 
         $spent = $earn = null;

--- a/code/Dotdigitalgroup/Email/Model/Campaign.php
+++ b/code/Dotdigitalgroup/Email/Model/Campaign.php
@@ -155,7 +155,7 @@ class Dotdigitalgroup_Email_Model_Campaign extends Mage_Core_Model_Abstract
                             $campaign->getEmail(), $websiteId
                         );
                         if (is_numeric($contactId)) {
-                            //update data fields for order review camapigns
+                            //update data fields
                             if ($campaign->getEventName() == 'Order Review') {
                                 $order = Mage::getModel('sales/order')
                                     ->loadByIncrementId($campaign->getOrderIncrementId());
@@ -187,6 +187,17 @@ class Dotdigitalgroup_Email_Model_Campaign extends Mage_Core_Model_Abstract
                                         $email, $data
                                     );
                                 }
+                            } elseif (
+                                $campaign->getEventName() == self::CAMPAIGN_EVENT_LOST_BASKET
+                            ) {
+                                $campaignCollection = $this->getCollection();
+                                // Skip if AC campaigns found with status processing for email in current cron run
+                                if ($campaignCollection->getNumberOfProcessingAcCampaignsForContact($email)) {
+                                    continue;
+                                }
+                                Mage::helper('ddg')->updateLastQuoteId(
+                                    $campaign->getQuoteId(), $email, $websiteId
+                                );
                             }
 
                             $campaignsToSend[$campaignId]['contacts'][] = $contactId;

--- a/code/Dotdigitalgroup/Email/Model/Connector/Order.php
+++ b/code/Dotdigitalgroup/Email/Model/Connector/Order.php
@@ -34,11 +34,11 @@ class Dotdigitalgroup_Email_Model_Connector_Order
     /**
      * @var array
      */
-    public $delivery_address = array();
+    public $delivery_address;
     /**
      * @var array
      */
-    public $billing_address = array();
+    public $billing_address;
     /**
      * @var array
      */
@@ -258,12 +258,14 @@ class Dotdigitalgroup_Email_Model_Connector_Order
      */
     public function expose()
     {
-        return array_diff_key(
+        $propreties = array_diff_key(
             get_object_vars($this),
             array_flip([
                 '_attributeSet'
             ])
         );
+
+        return array_filter($propreties);
     }
 
     protected function _getCustomAttributeValue($field, $orderData)

--- a/code/Dotdigitalgroup/Email/Model/Email/Template.php
+++ b/code/Dotdigitalgroup/Email/Model/Email/Template.php
@@ -40,6 +40,12 @@ class Dotdigitalgroup_Email_Model_Email_Template
 
         $variables['email'] = reset($emails);
         $variables['name']  = reset($names);
+        $storeId = null;
+
+        // Get the current store Id
+        if (isset($variables['store'])) {
+            $storeId = $variables['store']->getStoreId();
+        }
 
         ini_set('SMTP', Mage::getStoreConfig('system/smtp/host'));
         ini_set('smtp_port', Mage::getStoreConfig('system/smtp/port'));
@@ -93,7 +99,7 @@ class Dotdigitalgroup_Email_Model_Email_Template
         $mail->setFrom($this->getSenderEmail(), $this->getSenderName());
 
         try {
-            $transport = $helper->getTransport();
+            $transport = $helper->getTransport($storeId);
 
             $mail->send($transport);
 

--- a/code/Dotdigitalgroup/Email/Model/Newsletter/Observer.php
+++ b/code/Dotdigitalgroup/Email/Model/Newsletter/Observer.php
@@ -23,6 +23,12 @@ class Dotdigitalgroup_Email_Model_Newsletter_Observer
         $email = $subscriber->getEmail();
         $storeId = $subscriber->getStoreId();
         $subscriberStatus = $subscriber->getSubscriberStatus();
+
+        if ($subscriberStatus == Mage_Newsletter_Model_Subscriber::STATUS_NOT_ACTIVE or
+            $subscriberStatus == Mage_Newsletter_Model_Subscriber::STATUS_UNCONFIRMED) {
+            return $this;
+        }
+
         $websiteId = Mage::app()->getStore($subscriber->getStoreId())->getWebsiteId();
 
         //check if enabled

--- a/code/Dotdigitalgroup/Email/Model/Resource/Campaign/Collection.php
+++ b/code/Dotdigitalgroup/Email/Model/Resource/Campaign/Collection.php
@@ -12,4 +12,17 @@ class Dotdigitalgroup_Email_Model_Resource_Campaign_Collection
         parent::_construct();
         $this->_init('ddg_automation/campaign');
     }
+
+    /**
+     * @param $email
+     *
+     * @return int
+     */
+    public function getNumberOfProcessingAcCampaignsForContact($email)
+    {
+        return $this->addFieldToFilter('email', $email)
+            ->addFieldToFilter('event_name', Dotdigitalgroup_Email_Model_Campaign::CAMPAIGN_EVENT_LOST_BASKET)
+            ->addFieldToFilter('send_status', Dotdigitalgroup_Email_Model_Campaign::PROCESSING)
+            ->getSize();
+    }
 }

--- a/code/Dotdigitalgroup/Email/Model/Sales/Quote.php
+++ b/code/Dotdigitalgroup/Email/Model/Sales/Quote.php
@@ -327,8 +327,6 @@ class Dotdigitalgroup_Email_Model_Sales_Quote
             $quoteId    = $quote->getId();
             $items      = $quote->getAllItems();
             $email      = $quote->getCustomerEmail();
-            // update last quote id for the contact
-            Mage::helper('ddg')->updateLastQuoteId($quoteId, $email, $websiteId);
 
             $itemIds = $this->getQuoteItemIds($items);
             if ($mostExpensiveItem = $this->getMostExpensiveItems($items)) {
@@ -387,8 +385,6 @@ class Dotdigitalgroup_Email_Model_Sales_Quote
             $quoteId = $quote->getId();
             $items = $quote->getAllItems();
             $email = $quote->getCustomerEmail();
-            // update last quote id for the contact
-            Mage::helper('ddg')->updateLastQuoteId($quoteId, $email, $websiteId);
 
             $itemIds = $this->getQuoteItemIds($items);
             if ($mostExpensiveItem  = $this->getMostExpensiveItems($items)) {
@@ -484,8 +480,6 @@ class Dotdigitalgroup_Email_Model_Sales_Quote
         foreach ($quoteCollection as $quote) {
             $quoteId = $quote->getId();
             $email = $quote->getCustomerEmail();
-            // update last quote id for the contact
-            Mage::helper('ddg')->updateLastQuoteId($quoteId, $email, $websiteId);
 
             if ($mostExpensiveItem = $this->getMostExpensiveItems($quote->getAllItems())) {
                 Mage::helper('ddg')->updateAbandonedProductName(

--- a/code/Dotdigitalgroup/Email/etc/config.xml
+++ b/code/Dotdigitalgroup/Email/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Dotdigitalgroup_Email>
-            <version>6.3.7</version>
+            <version>6.3.8</version>
         </Dotdigitalgroup_Email>
     </modules>
     <frontend>

--- a/code/Dotdigitalgroup/Email/etc/system.xml
+++ b/code/Dotdigitalgroup/Email/etc/system.xml
@@ -2088,7 +2088,7 @@
             <frontend_type>text</frontend_type>
             <sort_order>7000</sort_order>
             <show_in_default>1</show_in_default>
-            <show_in_website>0</show_in_website>
+            <show_in_website>1</show_in_website>
             <show_in_store>0</show_in_store>
             <groups>
                 <ddg_transactional translate="label" module="ddg">
@@ -2096,7 +2096,7 @@
                     <frontend_type>text</frontend_type>
                     <sort_order>9000</sort_order>
                     <show_in_default>1</show_in_default>
-                    <show_in_website>0</show_in_website>
+                    <show_in_website>1</show_in_website>
                     <show_in_store>0</show_in_store>
                     <fields>
                         <enabled translate="label" module="ddg">
@@ -2105,7 +2105,7 @@
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
+                            <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </enabled>
                         <send_mode translate="label" module="ddg">
@@ -2114,14 +2114,14 @@
                             <source_model>ddg_automation/adminhtml_source_transactional_mode</source_model>
                             <sort_order>15</sort_order>
                             <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
+                            <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </send_mode>
                         <host translate="label" module="ddg">
                             <label>Host</label>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
+                            <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <backend_model>ddg_automation/adminhtml_model_transactional_host</backend_model>
                             <depends><send_mode>smtp</send_mode></depends>
@@ -2130,7 +2130,7 @@
                             <label>Username</label>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
+                            <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <backend_model>ddg_automation/adminhtml_model_transactional_username</backend_model>
                         </username>
@@ -2139,7 +2139,7 @@
                             <frontend_type>password</frontend_type>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
+                            <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </password>
                         <port translate="label" module="ddg">
@@ -2148,7 +2148,7 @@
                             <frontend_type>select</frontend_type>
                             <source_model>ddg_automation/adminhtml_source_transactional_port</source_model>
                             <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
+                            <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <depends><send_mode>smtp</send_mode></depends>
                         </port>
@@ -2158,7 +2158,7 @@
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
+                            <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                             <comment>Debug information in system.log file.</comment>
                         </debug_mode>


### PR DESCRIPTION
When running the contact sync with the Sweet Tooth integration enabled an exception occurs.

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'last_update_ts' in 'order clause', query was: SELECT CONCAT(main_table.quantity, ' ', currency_table.caption) AS `points_caption`, `main_table`.*, `currency_table`.`caption` AS `currency`, `currency_table`.`rewards_currency_id` AS `currency_id` FROM `rewards_transfer` AS `main_table` LEFT JOIN `rewards_currency` AS `currency_table` ON currency_table.rewards_currency_id=1 WHERE (`customer_id` = '155266') AND (main_table.status_id IN (5)) ORDER BY last_update_ts DESC
```

The column name ```last_update_ts``` was changed to ```updated_at``` in version 1.9.0 of the Sweet Tooth Module.

This pull request changes the column name used in the synchronisation to the new column name.
