### PR TITLE
Fix potential SQL injection

### DIFF
--- a/code/Dotdigitalgroup/Email/Model/Resource/Contact.php
+++ b/code/Dotdigitalgroup/Email/Model/Resource/Contact.php
@@ -305,7 +305,6 @@ class Dotdigitalgroup_Email_Model_Resource_Contact extends Mage_Core_Model_Resou
         }
 
         $write  = $this->_getWriteAdapter();
-        $emails = '"' . implode('","', $data) . '"';
 
         try {
             //un-subscribe from the email contact table.
@@ -316,7 +315,7 @@ class Dotdigitalgroup_Email_Model_Resource_Contact extends Mage_Core_Model_Resou
                     'subscriber_status' => Mage_Newsletter_Model_Subscriber::STATUS_UNSUBSCRIBED,
                     'suppressed' => 1
                 ),
-                "email IN($emails)"
+                $write->prepareSqlCondition('email', array('in' => $data))
             );
 
             // un-subscribe newsletter subscribers


### PR DESCRIPTION
The $data argument can contain data that can cause syntax errors in the query and thus may allow for malicious injection. Data should never be string concatenated into a query string without being escaped.