### PR TITLE
Email Controller - Get URLs from Magento methods instead of redirecting to relative URLs

### DIFF
--- a/code/Dotdigitalgroup/Email/controllers/EmailController.php
+++ b/code/Dotdigitalgroup/Email/controllers/EmailController.php
@@ -222,9 +222,10 @@ class Dotdigitalgroup_Email_EmailController
             if ($configCartUrl) {
                 $url = $configCartUrl;
             } else {
-                $url = $this->_quote->getStore()->getUrl('checkout/cart');
+                $url = 'checkout/cart';
             }
 
+            $url = $this->_quote->getStore()->getUrl($url);
             $this->_redirectUrl($url);
         } else {
             // customer will be redirected to cart after successful login


### PR DESCRIPTION
When clicking the Return To Basket button in abandoned cart emails the current method for a logged in  customer causes an infinite redirect loop, since the redirect is to goto the relative URL if you follow the instructions in the admin panel.
>Please provide the cart url. If no url provided then default cart url checkout/cart will be used. Only enter the url after base url. For example for http://www.localhost.com/checkout/cart only enter checkout/cart

i.e. you end up being redirected to something like this: `https://example.com/connector/email/getbasket/quote_id/12345/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/checkout/cart`

This change ensures that a full URL is generated for the redirect using the same method as the other side of the conditional.