### PR TITLE
Allow 0.00 floats to be synced in order insight

### DIFF
--- a/code/Dotdigitalgroup/Email/Model/Connector/Order.php
+++ b/code/Dotdigitalgroup/Email/Model/Connector/Order.php
@@ -282,7 +282,10 @@ class Dotdigitalgroup_Email_Model_Connector_Order
             ))
         );
 
-        return array_filter($properties);
+		// do not expose null or empty arrays (0 or 0.00 are OK)
+		return array_filter($properties, function ($value) {
+			return !is_null($value) && !(is_array($value) && empty($value));
+		});
     }
 
     protected function _getCustomAttributeValue($field, $orderData)


### PR DESCRIPTION
This PR modifies the `expose` method in the Order class to allow 0.00 floats to be synced for price-related fields.

Note we prevent both NULL values and empty arrays, because:
- import data is json_encoded when sending to Dotdigital API
- arrays with keys are sent as JSON objects
- empty arrays in import data will be sent as empty JSON arrays

If you push up order custom attribute data with order 1, you will have an insight data schema like e.g. 
```
{"custom":
   {"key":"value"}
}
```

If you then push up order 2 and there are no attributes set, this will be rejected with `JsonValueIncompatibleWithSchema` because the schema type is immutable, and an array does not match the object.
